### PR TITLE
Fix event creation for has many through associations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    herstory (0.1.1)
+    herstory (0.1.2)
       rails
 
 GEM

--- a/lib/herstory/active_record/callbacks/has_many_through_callbacks.rb
+++ b/lib/herstory/active_record/callbacks/has_many_through_callbacks.rb
@@ -29,7 +29,7 @@ module Herstory
     end
 
     def before_destroy(record)
-      first_class_was = @first_association_klass.find_by_id(record.send("#{@second_association_name}_id_was"))
+      first_class_was = @first_association_klass.find_by_id(record.send("#{@first_association_name}_id_was"))
       first_class_is = record.send(@first_association_name)
       second_class_was = @second_association_klass.find_by_id(record.send("#{@second_association_name}_id_was"))
       second_class_is = record.send(@second_association_name)

--- a/lib/herstory/version.rb
+++ b/lib/herstory/version.rb
@@ -1,3 +1,3 @@
 module Herstory
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/herstory/has_many_through_callbacks_spec.rb
+++ b/spec/herstory/has_many_through_callbacks_spec.rb
@@ -39,30 +39,75 @@ RSpec.describe Herstory::HasManyThroughCallbacks do
       last_event = new_shipment.events.reload.first
       expect(last_event.type).to eq('attached_to_arrival')
     end
+
+    it "does not prevent event creation when enclosing association creation in 'without_logging'" do
+
+      # It seems that even the original author of Herstory assumed
+      # that associating objects in a 'without_logging' block would
+      # prevent events from being created. Looks like this is not
+      # true.
+
+      expect do
+        Herstory.without_logging do
+          arrival.shipments << shipment
+        end
+      end.to change { shipment.events.reload.count }.by(1)
+               .and change { arrival.events.reload.count }.by(1)
+    end
   end
 
   context "when a record is removed from has_many through: collection" do
-    let(:arrival) { Herstory.without_logging { Arrival.create } }
-    let(:shipment) { Herstory.without_logging { Shipment.create } }
+
+    # The test setup now writes a shipment and and an arrival (that
+    # are never explicitly used in any test) to the database.  This
+    # allows the following tests to make sure that the methods
+    # gathering the different IDs required in the log entries are do
+    # not confuse shipment IDs with arrival IDs.
+
+    let(:shipment_id) { 1000003 }
+    let(:unused_arrival_id) { 1000003 }
+    let(:arrival_id) { 99991 }
+    let(:unused_shipment_id) { 99991 }
+
+    let!(:unused_arrival) { Herstory.without_logging { Arrival.create(id: unused_arrival_id) } }
+    let(:arrival) { Herstory.without_logging { Arrival.create(id: arrival_id) } }
+    let!(:unused_shipment) { Herstory.without_logging { Shipment.create(id: unused_shipment_id) } }
+    let(:shipment) { Herstory.without_logging { Shipment.create(id: shipment_id) } }
 
     before :each do
-      Herstory.without_logging do
-        arrival.shipments << shipment
-      end
+      arrival.shipments << shipment
+    end
 
+    it 'logs two events when deleting an association' do
       expect do
         arrival.shipments.delete shipment
       end.to change(Event, :count).by(2)
     end
 
+    it 'logs two two deletion events when deleting an association' do
+      expect do
+        arrival.shipments.delete shipment
+      end.to change(Event.where(type: ['shipment_detached', 'detached_from_arrival']), :count).by(2)
+    end
+
     it "logs an event on owner" do
-      last_event = arrival.events.reload.first
-      expect(last_event.type).to eq('shipment_detached')
+      arrival.shipments.delete shipment
+      deletion_event = arrival.events.reload.where(type: 'shipment_detached').first
+
+      expect(deletion_event.parent_type).to eq('Arrival')
+      expect(deletion_event.parent_id).to eq(arrival_id)
+      expect(deletion_event.previously_associated_object_type).to eq('Shipment')
+      expect(deletion_event.previously_associated_object_id).to eq(shipment_id)
     end
 
     it "logs an event on record" do
-      last_event = shipment.events.reload.first
-      expect(last_event.type).to eq('detached_from_arrival')
+        arrival.shipments.delete shipment
+      deletion_event = shipment.events.reload.where(type: 'detached_from_arrival').first
+
+      expect(deletion_event.parent_type).to eq('Shipment')
+      expect(deletion_event.parent_id).to eq(shipment_id)
+      expect(deletion_event.previously_associated_object_type).to eq('Arrival')
+      expect(deletion_event.previously_associated_object_id).to eq(arrival_id)
     end
   end
 


### PR DESCRIPTION
This pull request should fix a subtle problem with event creation for `has_many_through` associations.

This fix is required before https://github.com/chi-deutschland/chicargo-web/pull/4269 can be merged. 