### PR TITLE
Allow logging of attributes at creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,63 +27,30 @@ end
 
 ```
 
-
 ### Component Two: Logging Implementation
 
-A logger class that gets called from the extension with a minimal interface. You can (and probably will) replace this component to your heart's content. Herstory enables you to _take note_ of all changes to an AR model and its associations, but it's up to you how you log them.
+Herstory ships with a default logger class. It saves an `Event` model to persist change information to the DB.
 
-Herstory ships with a default logger class, which is unceremoniously called `ChangeLogger`. It saves an `Event` model to persist change information to the DB. You could do anything though, as long as it can deal with Herstory's interface methods.
+### Configuration
 
-See [Implementing a custom logger](#implementing-a-custom-logger) for details.
+Herstory accepts a hash of options that allow a rudimentary configuration of its behavior. As of today, the only valid option is `log_all_attributes_on_creation`. Adding
 
-## Caveats
+```ruby
+
+  self._herstory_options = { log_all_attributes_on_creation: true }
+
+```
+
+to your model after the `include Herstory` instructs Herstory to log all the parameters that were present when the model was created.
+
+### Caveats
 
 So much beta warning here. Although it's used in production software. But it might blow up and spew poisonous lizards LOOKING AND ACTING like docile puppies EVERYWHERE until it is TOO LATE.
 
-## Fine Print
+### Fine Print
 
 _Herstory_ does what it does by injecting `before_save` and `before_destroy` callbacks on the model you're watching and all models that you're watching through associations. It monitors the `belongs_to` part of any association.
 
-## Implementing a custom logger
-
-Great idea! Go right ahead. Make a class, any class, and have it conform to the following interface (it's all named arguments):
-
-`log_creation(record:, user: nil)`
-
-`log_destruction(record: user: nil)`
-
-`log_attribute_changes(record:, user: nil)`
-
-```ruby
-log_association_changes (
-  change:, # Can be :addition or :deletion
-  record:, # The record that has the association that's being logged
-  superordinate:, # See below
-  other_record:,  # The record that was added or deleted
-  user: nil # The user who done did it
-  )
-```
-
-About `superordinate:` - This information can be used to make sense of the relationship / hierarchy between two objects, which can't necessarily be inferred from the association definition. It serves to express _what_ is assigned to _what_. The included logger uses it to do some linguistic adjustments, e.g. sort out whether to save an Event á la `person_attached_to_contact` or `contact_attached_to_person`.
-
-Possible values are:
-  - `:record` - This end of the association is the superordinate, e.g. `Organization (record) has_and_belongs_to_many persons (other_record)`
-  - `:other_record` - The other end of the association is the superordinate, e.g. `Person (record) has_and_belongs_to_many organizations (other_record)`
-  - `:none` - They're both subordinate
-  - `:both` (**Default**) - They're both equally superordinate, e.g. `House has_and_belongs_to_many neighboring_houses`
-
-The `log_association_changes` method will only be called _once_, even if you define `logs_changes` on both ends of the association.
-
-When you're done, register it with _Herstory_ like so:
-
-`Herstory.logger = YourLoggerClass`
-
-Done and done.
-
-## But what about polymorphic associations?
+### But what about polymorphic associations?
 
 Define logs_changes on your polymorphic model, done.
-
-## Contributing
-
-Yeah, sure! All I care about (except basic manners) are SPECS for any bugs you report or changes you want to introduce. The actual fix/implementation is a distant second to good SPECS!

--- a/lib/herstory/active_record/callbacks/record_callbacks.rb
+++ b/lib/herstory/active_record/callbacks/record_callbacks.rb
@@ -1,10 +1,20 @@
+# frozen_string_literal: true
+
 module Herstory
   class RecordCallbacks
+    def initialize(options)
+      @options = options
+    end
+
     def after_save(record)
       return if Thread.current[:skip_logging]
 
-      if record.saved_change_to_id?
-        ChangeLogger.log_creation(record, Thread.current[:current_user])
+      if record.saved_change_to_id
+        if @options[:log_all_attributes_on_creation]
+          ChangeLogger.log_all_attributes_on_creation(record, Thread.current[:current_user])
+        else
+          ChangeLogger.log_creation(record, Thread.current[:current_user])
+        end
       else
         ChangeLogger.log_attribute_changes(record, Thread.current[:current_user])
       end

--- a/lib/herstory/active_record/logs_changes.rb
+++ b/lib/herstory/active_record/logs_changes.rb
@@ -5,6 +5,7 @@ module Herstory
     include HasEvents
 
     cattr_accessor(:_excluded_columns) { [] }
+    cattr_accessor(:_herstory_options) { { log_all_attributes_on_creation: false} }
 
     def self.logs_changes(options = {})
       # Don't do anything if this is not the first
@@ -17,7 +18,7 @@ module Herstory
           [:self]
         end
 
-        after_save RecordCallbacks.new
+        after_save RecordCallbacks.new(_herstory_options)
       end
 
       # extract excluded columns option

--- a/lib/herstory/change_logger.rb
+++ b/lib/herstory/change_logger.rb
@@ -3,6 +3,14 @@ class ChangeLogger
     record.log(type: 'created', user: user)
   end
 
+  def self.log_all_attributes_on_creation(record, user = nil)
+    attributes =
+      record
+        .attributes
+        .filter { |_key, value| value.present? }
+    record.log(type: 'attributes_at_creation', user: user, info: attributes)
+  end
+
   def self.log_association_change(change, record, superordinate, other_record, skip_logging_on_other=false, user=nil)
     unless %i( record other_record both none ).include? superordinate
       raise ArgumentError.new("Unknown value for ordinate '#{superordinate}'")

--- a/lib/herstory/version.rb
+++ b/lib/herstory/version.rb
@@ -1,3 +1,3 @@
 module Herstory
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
This pull request allows a model using Herstory for logging to ask Herstory to log all attributes at object creation.